### PR TITLE
chore: Format with air

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -8,3 +8,5 @@
 ^README\.Rmd$
 ^\.positai$
 ^\.claude$
+^[.]?air[.]toml$
+^\.vscode$

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "Posit.air-vscode"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "[r]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "Posit.air-vscode"
+  },
+  "[quarto]": {
+    "editor.formatOnSave": true,
+    "editor.defaultFormatter": "quarto.quarto"
+  }
+}

--- a/R/test.R
+++ b/R/test.R
@@ -73,6 +73,4 @@
 
 #' @param x A value
 #' @return Nothing
-test <- function(x = 1) {
-
-}
+test <- function(x = 1) {}

--- a/R/use-poisson-pkgdown.R
+++ b/R/use-poisson-pkgdown.R
@@ -14,12 +14,18 @@ use_poisson_pkgdown <- function(pkg = getwd()) {
 
   current_needs <- desc::desc_get("Config/Needs/website")
   needs <- if (!is.na(current_needs)) {
-    toString(c(as.character(current_needs), "poissonconsulting/poissontemplate"))
+    toString(c(
+      as.character(current_needs),
+      "poissonconsulting/poissontemplate"
+    ))
   } else {
     "poissonconsulting/poissontemplate"
   }
   desc::desc_set("Config/Needs/website" = needs)
-  cat(paste(cli::symbol$tick, "Registered GHA dependency on poissontemplate.\n"))
+  cat(paste(
+    cli::symbol$tick,
+    "Registered GHA dependency on poissontemplate.\n"
+  ))
 
   config_path <- find_pkgdown_config(pkg)
   if (is.null(config_path)) {
@@ -37,19 +43,31 @@ use_poisson_pkgdown <- function(pkg = getwd()) {
     }
     yaml::write_yaml(config, file.path(pkg, config_path))
   }
-  cat(paste(cli::symbol$tick, "Registered poissontemplate in pkgdown config.\n"))
-  cat(paste(cli::symbol$bullet, "Check that the config edits are all harmless.\n"))
+  cat(paste(
+    cli::symbol$tick,
+    "Registered poissontemplate in pkgdown config.\n"
+  ))
+  cat(paste(
+    cli::symbol$bullet,
+    "Check that the config edits are all harmless.\n"
+  ))
   cat(paste(cli::symbol$bullet, "Git commit and push to origin.\n"))
-  cat(paste(cli::symbol$bullet, "Contact Poisson consulting plausible owner to set up subdomain.\n"))
+  cat(paste(
+    cli::symbol$bullet,
+    "Contact Poisson consulting plausible owner to set up subdomain.\n"
+  ))
 
   # TODO: traffic analytics setup?
 }
 
 find_pkgdown_config <- function(pkg) {
   possible_paths <- c(
-    "_pkgdown.yml", "_pkgdown.yaml",
-    "pkgdown/_pkgdown.yml", "pkgdown/_pkgdown.yaml",
-    "inst/_pkgdown.yml", "inst/_pkgdown.yaml"
+    "_pkgdown.yml",
+    "_pkgdown.yaml",
+    "pkgdown/_pkgdown.yml",
+    "pkgdown/_pkgdown.yaml",
+    "inst/_pkgdown.yml",
+    "inst/_pkgdown.yaml"
   )
   for (path in possible_paths) {
     if (file.exists(file.path(pkg, path))) {

--- a/air.toml
+++ b/air.toml
@@ -1,0 +1,7 @@
+[format]
+line-width = 80
+indent-width = 2
+indent-style = "space"
+line-ending = "auto"
+persistent-line-breaks = true
+default-exclude = true


### PR DESCRIPTION
Adds air formatting following the org standard (as in `chk`):

- `air.toml` with the standard `[format]` settings
- `.vscode/` settings recommending and enabling format-on-save with Posit air
- `.Rbuildignore` entries for `air.toml` and `.vscode`
- All R source formatted with `air format .` (air 0.9.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)